### PR TITLE
Updates to the code to allow it working on Terraform version 1.1.9

### DIFF
--- a/image.tf
+++ b/image.tf
@@ -22,7 +22,9 @@ resource "ibm_is_image" "custom_image" {
   timeouts {
     create = "300m"
   }
-  lifecycle {
-    replace_triggered_by = [null_resource.value_of_qcow2.id]
-  }
+  # Commenting it for now since it needs terraform 1.2.x, and schematics won't
+  # support that until end of Q3.
+  #lifecycle {
+  #  replace_triggered_by = [null_resource.value_of_qcow2.id]
+  #}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,8 +73,10 @@ variable "total_ipv4_address_count" {
 
 variable "mover_image_name" {
   # Regular expresions allowed
+  # Only Terraform 1.2 can connect to Ubuntu 22.
+  # Ubuntu 20.04 is more widely supported
   description = "image used for the VSI data mover"
-  default = ".*ubuntu.*22-04.*amd64.*"
+  default = ".*ubuntu.*20-04.*amd64.*"
 }
 
 variable "mover_profile" {


### PR DESCRIPTION
The goal is to make these terraform scripts part of schematics. However,
schematics does not support Terraform 1.2.x. Hence this commit removes the
features that would demand Terraform 1.2.x, there by enabling this product
to be deployable via schematics.

Also, use Ubuntu:20.04 as the OS version since 22.04 has new openssl algorithms that Terraform can't connect to.

When Schematics moves to 1.2.x in the future(Q3: 22 is tentative), we
can enable it back on.

Signed-off-by: Vishwanatha Subbanna <vishwa@linux.vnet.ibm.com>