### PR TITLE
Support custom endpoints

### DIFF
--- a/cloudinit_config.tf
+++ b/cloudinit_config.tf
@@ -23,11 +23,12 @@ write_files:
   content: ${filebase64(data.archive_file.data_mover.output_path)}
 - path: /tmp/data_mover.env
   content: |
-    cosEndpoint='https://${data.ibm_cos_bucket.cos_bucket.s3_endpoint_direct}'
+    cosEndpoint='${var.cos_endpoint == "" ? format("https://%s",data.ibm_cos_bucket.cos_bucket.s3_endpoint_direct) : var.cos_endpoint}'
     cosAPIKey='${sensitive(var.ibmcloud_api_key)}'
     cosInstanceCRN='${data.ibm_cos_bucket.cos_bucket.crn}'
     cosBucketName='${var.cos_bucket_name}'
     customImageName='${var.custom_image_name}'
+    iamEndpoint='${var.iam_endpoint_url}'
 EOF
   }
 

--- a/cos.tf
+++ b/cos.tf
@@ -1,10 +1,10 @@
-# data "ibm_resource_group" "cos_group" {
-#   name = "cos-resource-group"
-# }
+data "ibm_resource_group" "cos_group" {
+  name = var.cos_resource_group
+}
 
 data "ibm_resource_instance" "cos_instance" {
   name              = var.cos_instance_name
-  #resource_group_id = data.ibm_resource_group.cos_group.id
+  resource_group_id = data.ibm_resource_group.cos_group.id
   service           = "cloud-object-storage"
 }
 

--- a/data_mover/data_mover.py
+++ b/data_mover/data_mover.py
@@ -29,6 +29,7 @@ COS_INSTANCE_CRN = os.environ.get('cosInstanceCRN')
 COS_BUCKET_NAME = os.environ.get('cosBucketName')
 CUSTOM_IMAGE_NAME = os.environ.get('customImageName')
 CUSTOM_IMAGE_PATH = f"/volumes/qcow2/{CUSTOM_IMAGE_NAME}.qcow2"
+IAM_ENDPOINT = os.environ.get('iamEndpoint')
 
 METADATA_FILE = 'image-metadata.json'
 DEVMAP_FILE = 'devmap'
@@ -37,6 +38,7 @@ BOOT_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'boot/' # Trailing slashes
 DATA_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'data/' # Trailing slashes
 
 cos = ibm_boto3.resource('s3',
+    ibm_auth_endpoint=IAM_ENDPOINT+"/identity/token",
     ibm_api_key_id=COS_API_KEY,
     ibm_service_instance_id=COS_INSTANCE_CRN,
     config=Config(signature_version='oauth'),
@@ -308,4 +310,4 @@ if __name__ == '__main__':
     subprocess.check_call(shlex.split(f"sync"))
 
 
-    
+

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,18 @@ variable "cos_bucket_name" {
   type        = string
 }
 
+variable "cos_resource_group" {
+  description = "Resource group of the COS instance"
+  type        = string
+  default     = "Default"
+}
+
+variable "cos_endpoint" {
+  description = "Endpoint of COS service"
+  type        = string
+  default     = ""
+}
+
 variable "encryption_type" {
   type        = string
   default     = "provider_managed"
@@ -109,4 +121,10 @@ variable "mover_image_name" {
 variable "mover_profile" {
   description = "image used for the VSI data mover"
   default = "bx2d-16x64"
+}
+
+variable "iam_endpoint_url" {
+    description = "IAM endpoint url"
+    type        = string
+    default     = "https://iam.cloud.ibm.com"
 }


### PR DESCRIPTION
Allows support for additional customization including COS instances that resides in a custom resource group while keeping the default behavior, and custom endpoints to allow the tooling to be executed in staging and dev mzones by exporting the correct environment variables for the endpoint urls.  Verified in production and staging.