### PR TITLE
Fix the scenario where a custom z/OS image needs to override the parmlib location

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This set of scripts and automation can be used in conjunction with Wazi Image Bu
 
    This will create the VSI with the required data volumes. You might want to use the VSI serial console: the progress logs are written there by cloud init.
 
-Once compeleted successfully, the following can be observed as output:
+Once completed successfully, the following can be observed as output:
 
 - A bootable qcow2 image is uploaded to the IBM Cloud Object Storage bucket
 - A VPC block storage device, storing data volumes from the z/OS image, is created

--- a/data_mover/data_mover.py
+++ b/data_mover/data_mover.py
@@ -34,6 +34,7 @@ IAM_ENDPOINT = os.environ.get('iamEndpoint')
 METADATA_FILE = 'image-metadata.json'
 DEVMAP_FILE = 'devmap'
 ENV_OVERRIDES_FILE = 'env-overrides'
+PROPERTIES_JSON_FILE = 'properties.json'
 VOLUME_DIRECTORIES = '/volumes/'
 BOOT_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'boot/' # Trailing slashes
 DATA_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'data/' # Trailing slashes
@@ -48,7 +49,7 @@ cos = ibm_boto3.resource('s3',
 
 def copy_env_overrides_file():
     '''
-    Copy the env-overrides file, if it exists, to the boot volume
+    Copy the env-overrides file, if it exists, to the data volume
     '''
     env_overrides_exists = exists_in_bucket(COS_BUCKET_NAME, ENV_OVERRIDES_FILE)
     if env_overrides_exists:
@@ -56,6 +57,18 @@ def copy_env_overrides_file():
         with open(env_overrides_filename, 'wb') as file:
             file.write(get_item(COS_BUCKET_NAME, ENV_OVERRIDES_FILE).read())
         shutil.copy(env_overrides_filename, DATA_VOLUME_DIRECTORY)
+
+
+def copy_properties_file():
+    '''
+    Copy the properties.json file, if it exists, to the data volume
+    '''
+    properties_file_exists = exists_in_bucket(COS_BUCKET_NAME, PROPERTIES_JSON_FILE)
+    if properties_file_exists:
+        properties_filename = DATA_VOLUME_DIRECTORY + '../properties.json'
+        with open(properties_filename, 'wb') as file:
+            file.write(get_item(COS_BUCKET_NAME, PROPERTIES_JSON_FILE).read())
+        shutil.copy(properties_filename, DATA_VOLUME_DIRECTORY)
 
 
 def pull_metadata_file():
@@ -294,8 +307,9 @@ if __name__ == '__main__':
     # Define 5 concurrent processes to get the volume files with
     p = Pool(10)
 
-    # Copy the env-overrides file, if it exists
+    # Copy the env-overrides and/or properties.json files, if they exists in the COS bucket
     copy_env_overrides_file()
+    copy_properties_file()
 
     # Pull the metadata file from the COS bucket and get 
     # the boot volume and data volume names

--- a/data_mover/data_mover.py
+++ b/data_mover/data_mover.py
@@ -33,6 +33,7 @@ IAM_ENDPOINT = os.environ.get('iamEndpoint')
 
 METADATA_FILE = 'image-metadata.json'
 DEVMAP_FILE = 'devmap'
+ENV_OVERRIDES_FILE = 'env-overrides'
 VOLUME_DIRECTORIES = '/volumes/'
 BOOT_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'boot/' # Trailing slashes
 DATA_VOLUME_DIRECTORY = VOLUME_DIRECTORIES+'data/' # Trailing slashes
@@ -43,6 +44,18 @@ cos = ibm_boto3.resource('s3',
     ibm_service_instance_id=COS_INSTANCE_CRN,
     config=Config(signature_version='oauth'),
     endpoint_url=COS_ENDPOINT)
+
+
+def copy_env_overrides_file():
+    '''
+    Copy the env-overrides file, if it exists, to the boot volume
+    '''
+    env_overrides_exists = exists_in_bucket(COS_BUCKET_NAME, ENV_OVERRIDES_FILE)
+    if env_overrides_exists:
+        env_overrides_filename = DATA_VOLUME_DIRECTORY + '../env-overrides'
+        with open(env_overrides_filename, 'wb') as file:
+            file.write(get_item(COS_BUCKET_NAME, ENV_OVERRIDES_FILE).read())
+        shutil.copy(env_overrides_filename, DATA_VOLUME_DIRECTORY)
 
 
 def pull_metadata_file():
@@ -63,6 +76,23 @@ def pull_devmap():
     with open(volume + 'devmap', 'wb') as file:
         file.write(get_item(COS_BUCKET_NAME, DEVMAP_FILE).read())
     os.chown(volume + 'devmap', 999, 999)
+
+
+def exists_in_bucket(bucket_name, item_name):
+    '''
+    Validate that a given item name (file name) exists in the given bucket name.
+    '''
+    global bucket_contents
+    print('Checking if the item \'{1}\' exists in the bucket \'{0}\''.format(bucket_name, item_name))
+    try:
+        if item_name in get_bucket_contents(COS_BUCKET_NAME):
+            return True
+        else:
+            return False
+    except ClientError as ce:
+        exit('CLIENT ERROR: {0}\n'.format(ce))
+    except Exception as e:
+        exit('Unable to retrieve file contents: {0}'.format(e))
 
 
 def get_item(bucket_name, item_name):
@@ -263,6 +293,9 @@ if __name__ == '__main__':
 
     # Define 5 concurrent processes to get the volume files with
     p = Pool(10)
+
+    # Copy the env-overrides file, if it exists
+    copy_env_overrides_file()
 
     # Pull the metadata file from the COS bucket and get 
     # the boot volume and data volume names

--- a/my-settings.auto.tfvars-template
+++ b/my-settings.auto.tfvars-template
@@ -3,6 +3,7 @@ ibmcloud_api_key = "Your IBM Cloud API key"
 cos_instance_name = "Cloud Object Storage-xx"
 cos_bucket_name = "wazi-custom-image-bucket"
 cos_bucket_region = "ca-tor"
+cos_resource_group = "Default"
 
 custom_image_name = "wazi-custom-image"
 


### PR DESCRIPTION
If a custom z/OS image uses a non-recommended parmlib setup (i.e. not `%s.PARMLIB(IEASYM%s)` where %s is the loadparm value) then WaziaaS startup procedure won't be able to find the symbols and therefore won't be able to inject the IP address set by IBM Cloud.   Wazi Image Builder produces an override file (env-overrides) that WaziaaS will read to find the custom parmlib location during startup - this change ensures that this override file is on the data volume for WaziaaS to locate.